### PR TITLE
Add gcc path to stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -3,4 +3,5 @@ packages:
 - '.'
 extra-deps: []
 flags: {}
+with-gcc: /usr/bin/g++
 extra-package-dbs: []


### PR DESCRIPTION
This fixes an error I observed when building via `stack build` on Ubuntu 16.04:

```
cbits/clipper.hpp:29:18: fatal error: vector: No such file or directory
```

This requires a [recent version](https://github.com/commercialhaskell/stack/pull/2264) of `stack` (e.g. 1.2.0).
